### PR TITLE
Part 3 - Sharing dependencies

### DIFF
--- a/Cart/src/bootstrap.js
+++ b/Cart/src/bootstrap.js
@@ -1,0 +1,5 @@
+import faker from 'faker';
+
+const cartMessage = `<div> You have ${faker.random.number()} items in the cart.</div>`
+
+document.querySelector('#dev-cart').innerHTML = cartMessage;

--- a/Cart/src/bootstrap.js
+++ b/Cart/src/bootstrap.js
@@ -1,5 +1,24 @@
 import faker from 'faker';
 
-const cartMessage = `<div> You have ${faker.random.number()} items in the cart.</div>`
+const mount = (el) => {
+    const cartMessage = `<div> You have ${faker.random.number()} items in the cart.</div>`
+    el.innerHTML = cartMessage;
+}
 
-document.querySelector('#dev-cart').innerHTML = cartMessage;
+// Case - 1 : When we are running our cart microfrontend in isolation
+// Then, we are sure that document.querySelector("#dev-cart") will always give us an element
+// In this case, we can simply attach our content to that div
+
+// If our environment is development
+if(process.env.NODE_ENV === 'development'){
+    const el = document.querySelector('#dev-cart');
+
+    // and we have an element with id dev-cart
+    if(el) mount(el);
+}
+
+// Case - 2: When our cart are running in container app.
+// Then we are not sure that we'll always find an element with id dev-cart
+// In that case, we probably want the container app as how it can show our cart app.. Maybe on a user action..
+
+export { mount };

--- a/Cart/src/index.js
+++ b/Cart/src/index.js
@@ -1,5 +1,1 @@
-import faker from 'faker';
-
-const cartMessage = `<div> You have ${faker.random.number()} items in the cart.</div>`
-
-document.querySelector('#dev-cart').innerHTML = cartMessage;
+import('./bootstrap');

--- a/Cart/webpack.config.js
+++ b/Cart/webpack.config.js
@@ -13,7 +13,11 @@ module.exports = {
             exposes : {
                 './CartIndex': './src/index'
             },
-            shared: ['faker']
+            shared: {
+                faker : {
+                    singleton: true
+                }
+            }
         }),
         new HtmlWebpackPlugin({
             template: './public/index.html'

--- a/Cart/webpack.config.js
+++ b/Cart/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
             name: 'cart',
             filename: 'remoteEntry.js',
             exposes : {
-                './CartIndex': './src/index'
+                './CartIndex': './src/bootstrap'
             },
             shared: {
                 faker : {

--- a/Cart/webpack.config.js
+++ b/Cart/webpack.config.js
@@ -12,7 +12,8 @@ module.exports = {
             filename: 'remoteEntry.js',
             exposes : {
                 './CartIndex': './src/index'
-            }
+            },
+            shared: ['faker']
         }),
         new HtmlWebpackPlugin({
             template: './public/index.html'

--- a/Container/public/index.html
+++ b/Container/public/index.html
@@ -2,8 +2,8 @@
 <html>
     <head></head>
     <body>
-        <div id="dev-products"></div>
+        <div id="my-products"></div>
         <hr />
-        <div id="dev-cart"></div>
+        <div id="my-cart"></div>
     </body>
 </html>

--- a/Container/src/bootstrap.js
+++ b/Container/src/bootstrap.js
@@ -1,4 +1,7 @@
-import 'products/ProductsIndex';
-import 'cart/CartIndex'
+import { mount as  mountProduct } from 'products/ProductsIndex';
+import { mount as  mountCart } from 'cart/CartIndex'
+
+mountProduct(document.querySelector('#my-products'));
+mountCart(document.querySelector('#my-cart'));
 
 console.log('Hello from container !!');

--- a/Product List - PLP/src/bootstrap.js
+++ b/Product List - PLP/src/bootstrap.js
@@ -1,10 +1,30 @@
 import faker from 'faker';
 
-let products = '';
+const mount = (el) => {
+    let products = '';
 
-for(let i=0;i<10;i++){
-    const name = faker.commerce.productName();
-    products += `<div> ${name} </div>`
+    for(let i=0;i<10;i++){
+        const name = faker.commerce.productName();
+        products += `<div> ${name} </div>`
+    }
+
+    el.innerHTML = products
 }
 
-document.querySelector("#dev-products").innerHTML = products
+// Case - 1 : When we are running our products microfrontend in isolation
+// Then, we are sure that document.querySelector("#dev-products") will always give us an element
+// In this case, we can simply attach our content to that div
+
+// If our environment is development
+if(process.env.NODE_ENV === 'development'){
+    const el = document.querySelector('#dev-products');
+
+    // and we have an element with id dev-products
+    if(el) mount(el);
+}
+
+// Case - 2: When our products are running in container app.
+// Then we are not sure that we'll always find an element with id dev-products
+// In that case, we probably want the container app as how it can show our products app.. Maybe on a user action..
+
+export { mount };

--- a/Product List - PLP/src/bootstrap.js
+++ b/Product List - PLP/src/bootstrap.js
@@ -1,0 +1,10 @@
+import faker from 'faker';
+
+let products = '';
+
+for(let i=0;i<10;i++){
+    const name = faker.commerce.productName();
+    products += `<div> ${name} </div>`
+}
+
+document.querySelector("#dev-products").innerHTML = products

--- a/Product List - PLP/src/index.js
+++ b/Product List - PLP/src/index.js
@@ -1,10 +1,1 @@
-import faker from 'faker';
-
-let products = '';
-
-for(let i=0;i<10;i++){
-    const name = faker.commerce.productName();
-    products += `<div> ${name} </div>`
-}
-
-document.querySelector("#dev-products").innerHTML = products
+import('./bootstrap')

--- a/Product List - PLP/webpack.config.js
+++ b/Product List - PLP/webpack.config.js
@@ -12,7 +12,8 @@ module.exports = {
             filename: 'remoteEntry.js',
             exposes: {
                 './ProductsIndex': './src/index',
-            }
+            },
+            shared: ['faker']
         }),
         new HtmlWebpackPlugin({
             template: './public/index.html'

--- a/Product List - PLP/webpack.config.js
+++ b/Product List - PLP/webpack.config.js
@@ -11,7 +11,7 @@ module.exports = {
             name: 'products',
             filename: 'remoteEntry.js',
             exposes: {
-                './ProductsIndex': './src/index',
+                './ProductsIndex': './src/bootstrap',
             },
             shared: {
                 faker : {

--- a/Product List - PLP/webpack.config.js
+++ b/Product List - PLP/webpack.config.js
@@ -13,7 +13,11 @@ module.exports = {
             exposes: {
                 './ProductsIndex': './src/index',
             },
-            shared: ['faker']
+            shared: {
+                faker : {
+                    singleton: true
+                }
+            }
         }),
         new HtmlWebpackPlugin({
             template: './public/index.html'


### PR DESCRIPTION
In this PR:
1. Share dependency between microfrontends by using shared attribute from Module Federation Plugin
2. How to use singleton loading of a shared dependency
3. Refractor products and cart microfrontend